### PR TITLE
Fix a bug in .pack and .packDeps

### DIFF
--- a/lib/builtins/commands.js
+++ b/lib/builtins/commands.js
@@ -225,8 +225,8 @@ module.exports = function commands(repl) {
         , require_ = findexquire(res.path);
 
       log.info('Adding the following local dependencies to the replpad context:');
-      Object.keys(pack.dependencies)
-        .concat(Object.keys(pack.devDependencies))
+      Object.keys(pack.dependencies || {})
+        .concat(Object.keys(pack.devDependencies || {}))
         .sort()
         .forEach(function(dep){
           var name = dep.replace(/-/g, '_');


### PR DESCRIPTION
Calling `.pack` or `.packDeps` would throw if used inside a directory
with a package with no dependencies (or dev dependencies).