### PR TITLE
Fixing issues with atomic saves 

### DIFF
--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var fs          =  require('fs')
-  , path        =  require('path')
   , readdirp    =  require('readdirp')
+  , chokidar    =  require('chokidar')
   , utl         =  require('./utl')
   , log         =  require('./log')
   , watchers    =  {}
@@ -19,24 +19,23 @@ function watchFile(entry, eventName, startedWatching, update) {
   if (watchers[fullPath]) return;
   startedWatching(entry);
 
-  fs.watch(fullPath, { persistent: false }, function (event) {
-    if (event !== eventName) return;
+  chokidar.watch(fullPath, { persistent: true })
+    .on('change', function () {
+      var prevStat = watchers[fullPath].stat
+        , entry    = watchers[fullPath].entry
 
-    var prevStat = watchers[fullPath].stat
-      , entry    = watchers[fullPath].entry
+      fs.stat(fullPath, function (err, stat) {
+        if (err) return log.error('watcher', err);
 
-    fs.stat(fullPath, function (err, stat) {
-      if (err) return log.error('watcher', err);
+        // ignore atime changes (read access)
+        if ( prevStat
+          && dateEqual(prevStat.mtime, stat.mtime)
+          && dateEqual(prevStat.ctime, stat.ctime)) return;
 
-      // ignore atime changes (read access)
-      if ( prevStat
-        && dateEqual(prevStat.mtime, stat.mtime)
-        && dateEqual(prevStat.ctime, stat.ctime)) return;
-
-      watchers[fullPath].stat = stat
-      update(entry);
+        watchers[fullPath].stat = stat
+        update(entry);
+      });
     });
-  });
 }
 
 function watchTree(options, addedWatch, update, watching) {
@@ -50,24 +49,27 @@ function watchTree(options, addedWatch, update, watching) {
     if (watchedDirs[fullPath]) return;
     watchedDirs[fullPath] = true;
 
-    fs.watch(fullPath, { persistent: false }, function (event) {
-      if (event !== 'rename') return;
-      var cloned = utl.shallowClone(options);
+    chokidar.watch(fullPath, { persistent: true })
+      .on('add', function () {
+        var cloned = utl.shallowClone(options);
 
-      cloned.depth = 0;
-      cloned.root = fullPath;
+        cloned.depth = 0;
+        cloned.root = fullPath;
 
-      readdirp(cloned)
-        .on('warn', log.error)
-        .on('error', log.error)
-        .on('data', function (entry) {
-          try {
-            watchFile(entry, 'change', startedWatching, update);
-          } catch(e) {
-            log.error('Not watching: ' + entry.path);
-          }
-        });
-    });
+        readdirp(cloned)
+          .on('warn', log.error)
+          .on('error', log.error)
+          .on('data', function (entry) {
+            try {
+              watchFile(entry, 'change', startedWatching, update);
+            } catch(e) {
+              log.error('Not watching: ' + entry.path);
+            }
+          });
+      })
+      .on('unlink', function (path) {
+        watchers[fullPath] = void 0;
+      });
   }
 
   readdirp(options)

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "ansicolors": "~0.2.1",
     "ansistyles": "~0.1.1",
     "cardinal": "~0.4.2",
+    "chokidar": "~0.11.1",
     "escodegen": "0.0.15",
     "esprima": "~1.0.3",
     "find-parent-dir": "~0.1.0",

--- a/test/lib/dox/pack/get-packinfo.js
+++ b/test/lib/dox/pack/get-packinfo.js
@@ -22,14 +22,15 @@ test('\ngets cardinal packinfo', function (t) {
   });
 })
 
-test('\ngets marked packinfo', function (t) {
-  info('marked', function (err, res) {
+test('\ngets xtend packinfo', function (t) {
+  info('xtend', function (err, res) {
     t.notOk(err, 'no error')
-    t.equal(res.homepage, 'https://github.com/chjj/marked', 'homepage')
-    t.equal(res.url, 'https://github.com/chjj/marked', 'browseable github url')
-    
+    t.equal(res.homepage, 'https://github.com/Raynos/xtend', 'homepage')
+    t.equal(res.url, 'https://github.com/Raynos/xtend', 'browseable github url')
+
     // no idea why `res.readme` isn't defined on travis
     if (!process.env.TRAVIS) {
+      console.log(res);
       t.ok(res.readme.length > 0, 'readme string') 
       t.equal(res.readmeFilename, 'README.md', 'readme filename')
     }


### PR DESCRIPTION
This fixes #7.

Switching to [chokidar](https://github.com/paulmillr/chokidar) for better `fs.watch` support.  Chokidar fixes the issues that the built-in watch has with regards to atomic saves.

I removed the `require('path')` statement in `lib/watcher.js` as well since it was unused.

Also, the `marked` test for dox was failing since marked no longer includes the `readme` data that is required by the test (fresh `node_modules` install as of tonight), so I looked in the `node_modules` directory and saw that `xtend` provides the correct data, so made the switch to that so that the test cases would succeed.