### PR TITLE
Fixed fatal error when trying to toggle togglable commands.

### DIFF
--- a/lib/builtins/commands.js
+++ b/lib/builtins/commands.js
@@ -47,7 +47,7 @@ module.exports = function commands(repl) {
 
   function updateCompact() {
     log.info('Compact code ' + currently(config.feed.format.compact));
-    repl.commands['.compact'].help = compactHelp();
+    repl.commands['compact'].help = compactHelp();
   }
 
   repl.defineCommand('compact', {
@@ -80,7 +80,7 @@ module.exports = function commands(repl) {
 
   function updateHighlight() {
     log.info('Syntax highlight code ' + currently(config.highlight));
-    repl.commands['.highlight'].help = highlightHelp();
+    repl.commands['highlight'].help = highlightHelp();
   }
 
   repl.defineCommand('highlight', {
@@ -113,7 +113,7 @@ module.exports = function commands(repl) {
     
   function updateDepth() {
     log.info('Depth [%s]', config.inspect.depth);
-    repl.commands['.depth'].help = depthHelp();
+    repl.commands['depth'].help = depthHelp();
   }
 
   repl.defineCommand('depth', {
@@ -139,7 +139,7 @@ module.exports = function commands(repl) {
 
   function updateHidden() {
     log.info('Show hidden ' + currently(config.inspect.showHidden));
-    repl.commands['.hidden'].help = hiddenHelp();
+    repl.commands['hidden'].help = hiddenHelp();
   }
 
   repl.defineCommand('hidden', {
@@ -174,7 +174,7 @@ module.exports = function commands(repl) {
   function updateTalk() {
     if (!config.scriptietalkie) config.scriptietalkie = {};
     log.info('Evaluate piped code with scriptie-talkie ' + currently(config.scriptietalkie.active));
-    repl.commands['.talk'].help = talkHelp();
+    repl.commands['talk'].help = talkHelp();
   }
 
   repl.defineCommand('talk', {


### PR DESCRIPTION
When running `pad > .highlight` or similar, node would throw the following:

``` js
pad > .highlight
INFO Syntax highlight code [on]
/usr/local/lib/node_modules/replpad/lib/builtins/commands.js:83
    repl.commands['.highlight'].help = highlightHelp();
                                     ^
TypeError: Cannot set property 'help' of undefined
    at updateHighlight (/usr/local/lib/node_modules/replpad/lib/builtins/commands.js:83:38)
    at REPLServer.repl.defineCommand.action (/usr/local/lib/node_modules/replpad/lib/builtins/commands.js:92:13)
    at REPLServer.parseREPLKeyword (repl.js:706:16)
    at REPLServer.<anonymous> (repl.js:255:16)
    at REPLServer.emit (events.js:107:17)
    at REPLServer.Interface._onLine (readline.js:214:10)
    at REPLServer.Interface._line (readline.js:553:8)
    at REPLServer.Interface._ttyWrite (readline.js:830:14)
    at REPLServer.notifyingWrite (/usr/local/lib/node_modules/replpad/node_modules/readline-vim/readline-vim.js:51:23)
    at Object.self.handleInput (/usr/local/lib/node_modules/replpad/node_modules/readline-vim/lib/insert-mode.js:95:37)
```

The `commands` array doesn't contain commands prepended with a `.`, so I changed these update functions to reflect that.
