### PR TITLE
dox on https

### DIFF
--- a/lib/dox/core/print.js
+++ b/lib/dox/core/print.js
@@ -9,7 +9,7 @@ var fs           =  require('fs')
   , anchorHeader =  require('anchor-markdown-header')
   , log          =  require('../../log')
   , retrieve     =  require('./retrieve')
-  , rootUrl      =  format('http://nodejs.org/docs/%s/api', process.version)
+  , rootUrl      =  format('https://nodejs.org/docs/%s/api', process.version)
   ;
 
 function getUrls(mod) {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.14.0",
   "description": "Pipes content of files to a node repl whenever they change and adds many more features to enable a highly interactive coding experience.",
   "main": "repreprep.js",
+  "readme": "README.md",
   "bin": {
     "replpad": "./bin/replpad.js"
   },

--- a/test/lib/dox/core/retrieve.js
+++ b/test/lib/dox/core/retrieve.js
@@ -4,7 +4,7 @@
 var test     =  require('tap').test
   , retrieve =  require('../../../../lib/dox/core/retrieve')
   , format   =  require('util').format
-  , rootUrl  =  format('http://nodejs.org/docs/%s/api', process.version)
+  , rootUrl  =  format('https://nodejs.org/docs/%s/api', process.version)
 
 
 test('\nwhen I retrieve fs', function (t) {

--- a/test/lib/dox/pack/get-packinfo.js
+++ b/test/lib/dox/pack/get-packinfo.js
@@ -16,7 +16,7 @@ test('\ngets cardinal packinfo', function (t) {
   info('cardinal', function (err, res) {
     t.notOk(err, 'no error')
     t.equal(res.url, 'https://github.com/thlorenz/cardinal', 'browseable github url')
-    t.equal(res.readmeFilename, 'README.md', 'readme filename')
+    t.equal(res.readme, 'README.md', 'readme filename')
     t.ok(res.readme.length > 0, 'readme string')
     t.end()    
   });


### PR DESCRIPTION
Tested on 0.12, 4.2.4 and 5.3.0. One test `test/lib/findexquire.js` is failing, nothing related with this changes.